### PR TITLE
DevOps: Docker packaging fixes and CLI reliability

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,21 @@
+name: Docker Smoke
+
+on:
+  push:
+    branches: [ main, develop, docs ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  docker-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Build image
+        run: docker build -t gcp-docker-smoke .
+
+      - name: Verify packaged CLI entrypoint
+        run: docker run --rm gcp-docker-smoke drive-copy --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,27 @@
-# Use a multi-stage build to reduce the final image size
-# ================================
-# Stage 1: Dependencies
-# ================================
+# Multi-stage Dockerfile for gcp-drive-tools
+
 FROM python:3.12-slim-bookworm AS deps
 WORKDIR /app
 
-# Copy requirements file first for caching
-COPY requirements.txt .
+# Install the packaged project so the console script entrypoint is available.
+COPY pyproject.toml requirements.txt ./
+COPY gcp ./gcp
+RUN pip install --no-cache-dir .
 
-# Install dependencies
-RUN pip install --no-cache-dir -r requirements.txt
-
-# ================================
-# Stage 2: Application
-# ================================
 FROM python:3.12-slim-bookworm AS app
-
 WORKDIR /app
 
 # Create non-root user
 RUN groupadd --system appgroup && useradd --system --gid appgroup appuser
 
-# Copy application source code
-COPY copy_folder.py .
-
-# Copy dependencies from the previous stage
+# Copy installed packages and console scripts
 COPY --from=deps /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=deps /usr/local/bin /usr/local/bin
 
-# Change ownership to non-root user
-RUN chown -R appuser:appgroup /app
+# Ensure runtime output path exists and is writable by the app user
+RUN mkdir -p /app/outputs && chown -R appuser:appgroup /app
 
-# Switch to non-root user
 USER appuser
 
-# Command to run the Google Drive copy utility
-CMD ["python", "copy_folder.py"]
+ENTRYPOINT ["drive-copy"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,17 @@ GOOGLE_DRIVE_DESTINATION_FOLDER_ID=xyz456abc
 ### CLI Command
 
 ```bash
+# Canonical packaged entrypoint
 drive-copy
+
+# Optional: print required environment variable names
+drive-copy --help-env
+
+# Optional: preview copy scope without writing outputs or copying files
+drive-copy --dry-run
+
+# Alternate valid path (module execution)
+python -m gcp.copy_folder
 ```
 
 `drive-report` appears in older notes, but the packaged console script in `pyproject.toml` is `drive-copy`.

--- a/TASKS.md
+++ b/TASKS.md
@@ -8,30 +8,22 @@ Last Updated: 2026-03-27
 - [x] Add automated tests for copy logic and CLI entry paths.
 - [x] Add CI security workflows.
 - [x] Publish setup and environment docs in README and `.env.example`.
+- [x] Fix the Docker build failure in `Dockerfile`.
+  - Completed: 2026-03-27
+  - Evidence: `docker build -t gcp-devops-check .` succeeds from repo root and the image runs `drive-copy --help`.
+- [x] Add a Docker smoke test to CI.
+  - Completed: 2026-03-27
+  - Evidence: `.github/workflows/docker-smoke.yml` builds the image and runs `drive-copy --help`.
+- [x] Align README examples with the shipped CLI.
+  - Completed: 2026-03-27
+  - Evidence: README usage now lists `drive-copy` as canonical with valid `--help-env` and module-based alternatives.
+- [x] Add a `--dry-run` option for copy workflows.
+  - Completed: 2026-03-27
+  - Evidence: `drive-copy --dry-run` now previews scope without creating output files or issuing copy calls.
 
 ## In Progress
 
-- [ ] Fix the Docker build failure in `Dockerfile`.
-  - Priority: P0
-  - Problem: `docker build` still references `copy_folder.py` at the wrong path.
-  - Acceptance Criteria: the image builds from repo root and runs the packaged entrypoint cleanly.
-
 ## Todo
-
-- [ ] Add a Docker smoke test to CI.
-  - Priority: P1
-  - Problem: CI still misses container runtime regressions.
-  - Acceptance Criteria: the workflow builds the image and runs a basic command successfully.
-
-- [ ] Align README examples with the shipped CLI.
-  - Priority: P1
-  - Problem: command examples and module paths have drifted from the packaged entrypoint.
-  - Acceptance Criteria: README shows one canonical path and one valid alternate path.
-
-- [ ] Add a `--dry-run` option for copy workflows.
-  - Priority: P2
-  - Problem: users cannot preview planned copy operations safely.
-  - Acceptance Criteria: the CLI supports dry-run mode with summary output and no writes.
 
 - [ ] Add progress telemetry for long-running copy operations.
   - Priority: P2

--- a/gcp/copy_folder.py
+++ b/gcp/copy_folder.py
@@ -1,6 +1,7 @@
 '''
 A script using the Google Drive API to create reports and copy contents between folders.
 '''
+import argparse
 import os
 import csv
 import logging
@@ -273,19 +274,43 @@ def compare_csv_files(file1, file2):
         logging.error("VALIDATION FAILED - Source & Destination folder counts do not match.")
         print("ERROR: VALIDATION FAILED!")
 
-def main():
+def main(argv=None):
     """Main entry point for CLI."""
     global service  # pylint: disable=global-statement
 
-    # Ensure the outputs directory exists and attach the file log handler.
-    # This is done here (not at module level) to avoid FileNotFoundError on import
-    # when the directory does not yet exist (the original RCA for CI failures).
-    os.makedirs(OUTPUTS_DIRECTORY, exist_ok=True)
-    timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')
-    log_file_path = os.path.join(OUTPUTS_DIRECTORY, f'gcp-{timestamp}.log')
-    file_handler = logging.FileHandler(log_file_path)
-    file_handler.setFormatter(logging.Formatter(LOG_FILE_FORMAT))
-    logging.getLogger().addHandler(file_handler)
+    parser = argparse.ArgumentParser(
+        prog='drive-copy',
+        description='Google Drive report and copy utility',
+    )
+    parser.add_argument(
+        '--help-env',
+        action='store_true',
+        help='Show required environment variables and exit',
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Preview source counts and planned copy target without writing outputs or copying files',
+    )
+    args, _ = parser.parse_known_args(argv)
+
+    if args.help_env:
+        print('Required environment variables:')
+        print(f'- {CLIENT_ID_ENV_VAR}')
+        print(f'- {SOURCE_FOLDER_ID_ENV_VAR}')
+        print(f'- {DESTINATION_FOLDER_ID_ENV_VAR}')
+        return
+
+    if not args.dry_run:
+        # Ensure the outputs directory exists and attach the file log handler.
+        # This is done here (not at module level) to avoid FileNotFoundError on import
+        # when the directory does not yet exist (the original RCA for CI failures).
+        os.makedirs(OUTPUTS_DIRECTORY, exist_ok=True)
+        timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')
+        log_file_path = os.path.join(OUTPUTS_DIRECTORY, f'gcp-{timestamp}.log')
+        file_handler = logging.FileHandler(log_file_path)
+        file_handler.setFormatter(logging.Formatter(LOG_FILE_FORMAT))
+        logging.getLogger().addHandler(file_handler)
 
     print("Google Drive Report & Copy Tool")
     print("Running copy_folder script...")
@@ -319,12 +344,28 @@ def main():
     destination_folder_name = service.files().get(fileId=destination_folder_id, fields='name').execute()
     # pylint: enable=no-member
 
+    total_num_files, total_num_folders = count_child_objects(source_folder_id, service)
+
+    if args.dry_run:
+        print('DRY RUN: no files will be copied and no output artifacts will be written.')
+        print(
+            f"Source '{source_folder_name['name']}' -> Destination '{destination_folder_name['name']}'"
+        )
+        print(f'Planned object scan: files={total_num_files}, folders={total_num_folders}')
+        logging.info(
+            "DRY RUN: source=%s destination=%s files=%d folders=%d",
+            source_folder_name['name'],
+            destination_folder_name['name'],
+            total_num_files,
+            total_num_folders,
+        )
+        return
+
     logging.info("STARTING ASSESSMENTS...")
     # ASSESSEMENT 1 - Write the results to a CSV file
     csv_file = './outputs/assessment-1.csv'
     with open(csv_file, 'w', newline='', encoding='utf-8') as output_file:
         # Get the name of the source folder
-        total_num_files, total_num_folders = count_child_objects(source_folder_id, service)
         writer = csv.writer(output_file)
         writer.writerow(['Folder Name', 'Number of Files', 'Number of Folders'])
         writer.writerow([source_folder_name['name'], total_num_files, total_num_folders])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -325,3 +325,50 @@ class TestMainIntegration:
         assert any('assessment-1.csv' in call for call in calls)
         assert any('assessment-2.csv' in call for call in calls)
         assert any('assessment-3.csv' in call for call in calls)
+
+
+class TestMainDryRun:
+    """Dry-run mode should avoid writes and copy operations."""
+
+    @patch('gcp.copy_folder.authenticate_and_authorize')
+    @patch('gcp.copy_folder.create_drive_service')
+    @patch('gcp.copy_folder.count_child_objects')
+    @patch('gcp.copy_folder.add_child_folders')
+    @patch('gcp.copy_folder.copy_child_objects')
+    @patch('gcp.copy_folder.compare_csv_files')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('os.environ.get')
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,unused-argument
+    def test_main_dry_run_skips_copy_and_writes(
+        self,
+        mock_env,
+        mock_file_open,
+        mock_compare,
+        mock_copy,
+        mock_add_child,
+        mock_count,
+        mock_create_service,
+        mock_auth,
+    ):
+        env_vars = {
+            'GOOGLE_DRIVE_CLIENT_ID_FILE': 'client_id.json',
+            'GOOGLE_DRIVE_SOURCE_FOLDER_ID': 'source123',
+            'GOOGLE_DRIVE_DESTINATION_FOLDER_ID': 'dest456',
+        }
+        mock_env.side_effect = env_vars.get
+
+        mock_auth.return_value = MagicMock()
+        mock_service = MagicMock()
+        mock_create_service.return_value = mock_service
+        mock_service.files().get().execute.side_effect = [
+            {'name': 'Source Folder'},
+            {'name': 'Destination Folder'},
+        ]
+        mock_count.return_value = (10, 5)
+
+        main(['--dry-run'])
+
+        mock_copy.assert_not_called()
+        mock_add_child.assert_not_called()
+        mock_compare.assert_not_called()
+        mock_file_open.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -350,6 +350,7 @@ class TestMainDryRun:
         mock_create_service,
         mock_auth,
     ):
+        """Verify that --dry-run exits before performing copies or writing output files."""
         env_vars = {
             'GOOGLE_DRIVE_CLIENT_ID_FILE': 'client_id.json',
             'GOOGLE_DRIVE_SOURCE_FOLDER_ID': 'source123',


### PR DESCRIPTION
## Summary

Continue Docker-first DevOps stabilization, improve CLI reliability, and fix CI quality gate failures. This PR ensures the packaged `drive-copy` entrypoint works correctly in Docker, adds smoke-test validation, and resolves a Pylint convention violation that was causing CI to exit with a non-zero status.

## Changes

- Add CLI argument parsing to support `--help-env` and `--dry-run`, with dry-run early exit that skips copy operations and output writes.
- Update Docker packaging to install the project as a package and run the `drive-copy` console script by default.
- Add a GitHub Actions workflow to smoke-test `docker build` + CLI startup.
- Align docs/tasks/roadmap with the validated CLI state.
- Fix Pylint CI failure (exit code 16 — convention message `C0116`) by adding missing docstring to `test_main_dry_run_skips_copy_and_writes` in `tests/test_main.py`.

## Testing

- Pylint run locally after fix: rated **10.00/10**, exit code **0**.
- Container build/run and test-stack checks completed during this workstream.

```bash
pylint $(git ls-files '*.py')
# Your code has been rated at 10.00/10
```

## Screenshots (optional)

N/A

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if needed)
- [ ] Linked to related issues / tasks
- [x] Follows project conventions
- [x] Code is well-documented and readable
- [x] Commits are logically organized