### PR TITLE
fix(lint): apply black/isort formatting and resolve pylint positional-args violation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ drive-copy --help-env
 # Optional: preview copy scope without writing outputs or copying files
 drive-copy --dry-run
 
+# Copy mode logs periodic progress telemetry and a final elapsed-time summary
+# (for long-running folder copies)
+drive-copy
+
 # Alternate valid path (module execution)
 python -m gcp.copy_folder
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,8 +18,7 @@ Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## 2026 Q3 (Planned)
 
-- [ ] Add dry-run mode for copy operations.
-- [ ] Add progress telemetry for large folder copies.
+- [x] Add progress telemetry for large folder copies.
 - [ ] Add selective copy filters by file type.
 
 ## 2026 Q4 (Exploratory)

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,8 +25,9 @@ Last Updated: 2026-04-03 (pmo/q2-2026-planning)
 
 ## Todo
 
-- [ ] Add progress telemetry for long-running copy operations.
-  - Priority: P2
-  - Problem: large copy jobs still provide poor visibility.
-  - Acceptance Criteria: the tool logs periodic progress updates and a final duration summary.
+## Done
+
+- [x] Add progress telemetry for long-running copy operations.
+  - Completed: 2026-04-03
+  - Evidence: `gcp/copy_folder.py` now logs periodic `COPY PROGRESS` updates plus a final `COPY PROGRESS SUMMARY` with elapsed duration; covered by `tests/test_copy_folder_extended.py`.
 

--- a/docs/HANDOFF-progress-telemetry-20260403.md
+++ b/docs/HANDOFF-progress-telemetry-20260403.md
@@ -1,0 +1,24 @@
+# Handoff: Copy Progress Telemetry (2026-04-03)
+
+## Summary
+Implemented progress telemetry for long-running Google Drive copy jobs so operators can see incremental progress and final elapsed duration.
+
+## Changes
+- Added telemetry tracker helpers in `gcp/copy_folder.py`.
+- `copy_child_objects()` now records:
+  - copied file count,
+  - created folder count,
+  - failed file count,
+  - elapsed runtime.
+- Added periodic `COPY PROGRESS` logs every configurable operation interval.
+- Added final `COPY PROGRESS SUMMARY` log with total elapsed duration.
+- Preserved existing retry behavior and recursive copy flow.
+
+## Tests
+- Added telemetry assertions in `tests/test_copy_folder_extended.py`.
+- Focused validation command (Docker):
+  - `docker run --rm -v ${PWD}:/app -w /app python:3.11-slim sh -lc "pip install -r requirements-dev.txt && pytest tests/test_copy_folder_extended.py -q"`
+
+## Tracking Updates
+- Marked telemetry task complete in `TASKS.md`.
+- Updated roadmap telemetry status in `ROADMAP.md`.

--- a/gcp/copy_folder.py
+++ b/gcp/copy_folder.py
@@ -1,38 +1,42 @@
-'''
+"""
 A script using the Google Drive API to create reports and copy contents between folders.
-'''
+"""
+
 import argparse
-import os
 import csv
-import logging
 import datetime
+import logging
+import os
 import time
+
 import pandas as pd
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError # pylint: disable=ungrouped-imports
+from googleapiclient.errors import HttpError  # pylint: disable=ungrouped-imports
 
 # Define API scopes
 SCOPES = [
-    'https://www.googleapis.com/auth/drive',
-    'https://www.googleapis.com/auth/drive.metadata.readonly'
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
 ]
 
 # Environment variables
-CLIENT_ID_ENV_VAR = 'GOOGLE_DRIVE_CLIENT_ID_FILE'
-SOURCE_FOLDER_ID_ENV_VAR = 'GOOGLE_DRIVE_SOURCE_FOLDER_ID'
-DESTINATION_FOLDER_ID_ENV_VAR = 'GOOGLE_DRIVE_DESTINATION_FOLDER_ID'
+CLIENT_ID_ENV_VAR = "GOOGLE_DRIVE_CLIENT_ID_FILE"
+SOURCE_FOLDER_ID_ENV_VAR = "GOOGLE_DRIVE_SOURCE_FOLDER_ID"
+DESTINATION_FOLDER_ID_ENV_VAR = "GOOGLE_DRIVE_DESTINATION_FOLDER_ID"
 
 # Script Constants
-MISSING_ENVAR_TXT = 'Missing environment variable for'
-MIME_FOLDER = 'application/vnd.google-apps.folder'
+MISSING_ENVAR_TXT = "Missing environment variable for"
+MIME_FOLDER = "application/vnd.google-apps.folder"
 DEFAULT_PROGRESS_LOG_EVERY = 25
 
 # Directories and filenames
-OUTPUTS_DIRECTORY = './outputs/'
+OUTPUTS_DIRECTORY = "./outputs/"
 
 # Log format used when initializing the file handler in main()
-LOG_FILE_FORMAT = '%(asctime)s %(levelname)s %(message)s %(filename)s %(funcName)s %(lineno)d'
+LOG_FILE_FORMAT = (
+    "%(asctime)s %(levelname)s %(message)s %(filename)s %(funcName)s %(lineno)d"
+)
 
 # RCA: logging.basicConfig(filename=...) was previously called at module level, which
 # attempted to open ./outputs/<log>.log immediately on import.  When the outputs/
@@ -46,6 +50,7 @@ logging.basicConfig(level=logging.INFO, format=LOG_FILE_FORMAT)
 # Module-level variables will be initialized in main()
 # This prevents execution on import
 service = None  # pylint: disable=invalid-name
+
 
 # Create a flow to handle the OAuth2 authentication
 def authenticate_and_authorize(client_id_file, api_scopes):
@@ -66,6 +71,7 @@ def authenticate_and_authorize(client_id_file, api_scopes):
         return auth_credentials
     return None
 
+
 def create_drive_service(valid_credentials):
     """
     Creates a Google Drive API service object.
@@ -76,11 +82,13 @@ def create_drive_service(valid_credentials):
     Returns:
         service (googleapiclient.discovery.Resource): The Drive API service object.
     """
-    return build('drive', 'v3', credentials=valid_credentials)
+    return build("drive", "v3", credentials=valid_credentials)
+
 
 # MAGIC Constants - to improve readability & linting
 # Disable pylint for no-member at the function level
 # pylint: disable=no-member
+
 
 # Define a function to count files and folders
 def count_files_and_folders(folder_id, drive_service=None):
@@ -97,19 +105,24 @@ def count_files_and_folders(folder_id, drive_service=None):
     """
     svc = drive_service or service
     # Count Files
-    query = (f"'{folder_id}' in parents and mimeType != '{MIME_FOLDER}' "
-             f"and trashed = false")
+    query = (
+        f"'{folder_id}' in parents and mimeType != '{MIME_FOLDER}' "
+        f"and trashed = false"
+    )
     results = svc.files().list(q=query).execute()
-    files = results.get('files', [])
+    files = results.get("files", [])
     num_files = len(files)
     # Count Folders
-    query = (f"'{folder_id}' in parents and mimeType = '{MIME_FOLDER}' "
-             f"and trashed = false")
+    query = (
+        f"'{folder_id}' in parents and mimeType = '{MIME_FOLDER}' "
+        f"and trashed = false"
+    )
     results = svc.files().list(q=query).execute()
-    folders = results.get('files', [])
+    folders = results.get("files", [])
     num_folders = len(folders)
 
     return num_files, num_folders
+
 
 # Define a function to count child objects recursively
 def count_child_objects(folder_id, drive_service=None):
@@ -127,14 +140,14 @@ def count_child_objects(folder_id, drive_service=None):
     svc = drive_service or service
     query = f"'{folder_id}' in parents and trashed = false"
     results = svc.files().list(q=query).execute()
-    files_and_folders = results.get('files', [])
+    files_and_folders = results.get("files", [])
     num_files = 0
     num_folders = 0
 
     for item in files_and_folders:
-        if item['mimeType'] == 'application/vnd.google-apps.folder':
+        if item["mimeType"] == "application/vnd.google-apps.folder":
             # It's a folder, increment folder count
-            child_num_files, child_num_folders = count_child_objects(item['id'], svc)
+            child_num_files, child_num_folders = count_child_objects(item["id"], svc)
             num_files += child_num_files
             num_folders += child_num_folders + 1
         else:
@@ -143,40 +156,45 @@ def count_child_objects(folder_id, drive_service=None):
 
     return num_files, num_folders
 
+
 # Define a function to copy child objects recursively
 def _create_progress_tracker(progress_log_every):
     return {
-        'start_time': time.monotonic(),
-        'copied_files': 0,
-        'created_folders': 0,
-        'failed_files': 0,
-        'processed_since_log': 0,
-        'progress_log_every': max(1, int(progress_log_every)),
+        "start_time": time.monotonic(),
+        "copied_files": 0,
+        "created_folders": 0,
+        "failed_files": 0,
+        "processed_since_log": 0,
+        "progress_log_every": max(1, int(progress_log_every)),
     }
 
 
 def _log_progress_if_needed(progress_tracker, force=False):
-    if not force and progress_tracker['processed_since_log'] < progress_tracker['progress_log_every']:
+    if (
+        not force
+        and progress_tracker["processed_since_log"]
+        < progress_tracker["progress_log_every"]
+    ):
         return
 
-    elapsed = time.monotonic() - progress_tracker['start_time']
+    elapsed = time.monotonic() - progress_tracker["start_time"]
     logging.info(
-        'COPY PROGRESS: files=%d folders=%d failed=%d elapsed=%.2fs',
-        progress_tracker['copied_files'],
-        progress_tracker['created_folders'],
-        progress_tracker['failed_files'],
+        "COPY PROGRESS: files=%d folders=%d failed=%d elapsed=%.2fs",
+        progress_tracker["copied_files"],
+        progress_tracker["created_folders"],
+        progress_tracker["failed_files"],
         elapsed,
     )
-    progress_tracker['processed_since_log'] = 0
+    progress_tracker["processed_since_log"] = 0
 
 
 def _log_progress_summary(progress_tracker):
-    elapsed = time.monotonic() - progress_tracker['start_time']
+    elapsed = time.monotonic() - progress_tracker["start_time"]
     logging.info(
-        'COPY PROGRESS SUMMARY: files=%d folders=%d failed=%d total_elapsed=%.2fs',
-        progress_tracker['copied_files'],
-        progress_tracker['created_folders'],
-        progress_tracker['failed_files'],
+        "COPY PROGRESS SUMMARY: files=%d folders=%d failed=%d total_elapsed=%.2fs",
+        progress_tracker["copied_files"],
+        progress_tracker["created_folders"],
+        progress_tracker["failed_files"],
         elapsed,
     )
 
@@ -185,6 +203,7 @@ def copy_child_objects(
     src_folder_id,
     dest_folder_id,
     drive_service=None,
+    *,
     max_retries=1,
     progress_tracker=None,
     progress_log_every=DEFAULT_PROGRESS_LOG_EVERY,
@@ -205,61 +224,69 @@ def copy_child_objects(
     # List files in the source folder
     query = f"'{src_folder_id}' in parents"
     results = svc.files().list(q=query).execute()
-    files = results.get('files', [])
+    files = results.get("files", [])
 
     try:
         # Copy each file to the destination folder
         for file in files:
-            file_metadata = {'name': file['name'], 'parents': [dest_folder_id]}
+            file_metadata = {"name": file["name"], "parents": [dest_folder_id]}
             # Retry loop
             for retry_attempt in range(max_retries):
                 try:
                     # Attempt to copy the file
-                    svc.files().copy(fileId=file['id'], body=file_metadata).execute()
-                    tracker['copied_files'] += 1
-                    tracker['processed_since_log'] += 1
+                    svc.files().copy(fileId=file["id"], body=file_metadata).execute()
+                    tracker["copied_files"] += 1
+                    tracker["processed_since_log"] += 1
                     _log_progress_if_needed(tracker)
                     # If the copy is successful, break out of the retry loop
                     break
                 except HttpError as error_msg:
                     if retry_attempt < max_retries - 1:
                         # Log the error and retry
-                        logging.error("Error copying file %s, retrying... (%d/%d)",
-                                      file['name'], retry_attempt + 1, max_retries)
+                        logging.error(
+                            "Error copying file %s, retrying... (%d/%d)",
+                            file["name"],
+                            retry_attempt + 1,
+                            max_retries,
+                        )
                     else:
                         # If all retries fail, log the error and move on to the next file
-                        logging.error("Error copying file %s after %d retries: %s",
-                                      file['name'], max_retries, error_msg)
-                        tracker['failed_files'] += 1
-                        tracker['processed_since_log'] += 1
+                        logging.error(
+                            "Error copying file %s after %d retries: %s",
+                            file["name"],
+                            max_retries,
+                            error_msg,
+                        )
+                        tracker["failed_files"] += 1
+                        tracker["processed_since_log"] += 1
                         _log_progress_if_needed(tracker)
                         break
 
     except HttpError as error_msg:
         # Handle errors related to copying files
-        handle_copy_error(file['name'], error_msg, svc)
+        handle_copy_error(file["name"], error_msg, svc)
 
     # List folders in the source folder
     query = f"'{src_folder_id}' in parents and mimeType = '{MIME_FOLDER}'"
     results = svc.files().list(q=query).execute()
-    folders = results.get('files', [])
+    folders = results.get("files", [])
 
     # Recursively copy child objects to the destination folder while preserving structure
     for folder in folders:
         # Create a new folder in the destination with the same name
         new_folder_metadata = {
-            'name': folder['name'],
-            'parents': [dest_folder_id],
-            'mimeType': 'application/vnd.google-apps.folder'
+            "name": folder["name"],
+            "parents": [dest_folder_id],
+            "mimeType": "application/vnd.google-apps.folder",
         }
-        new_folder = svc.files().create(body=new_folder_metadata, fields='id').execute()
-        tracker['created_folders'] += 1
-        tracker['processed_since_log'] += 1
+        new_folder = svc.files().create(body=new_folder_metadata, fields="id").execute()
+        tracker["created_folders"] += 1
+        tracker["processed_since_log"] += 1
         _log_progress_if_needed(tracker)
         # Recursively copy the child objects into the new folder
         copy_child_objects(
-            folder['id'],
-            new_folder['id'],
+            folder["id"],
+            new_folder["id"],
             svc,
             max_retries=max_retries,
             progress_tracker=tracker,
@@ -269,6 +296,7 @@ def copy_child_objects(
     if root_call:
         _log_progress_if_needed(tracker, force=True)
         _log_progress_summary(tracker)
+
 
 # Define a function to handle copy errors
 def handle_copy_error(file_or_folder_name, error, drive_service=None):
@@ -282,21 +310,22 @@ def handle_copy_error(file_or_folder_name, error, drive_service=None):
     """
     svc = drive_service or service
     # If the error is related to copying a file, try to retrieve its parent folder(s)
-    if isinstance(error, HttpError) and 'fileId' in error.__dict__:
-        file_id = error.__dict__['fileId']
+    if isinstance(error, HttpError) and "fileId" in error.__dict__:
+        file_id = error.__dict__["fileId"]
         try:
             # Retrieve the file's metadata to get parent folder(s)
-            file_metadata = svc.files().get(fileId=file_id, fields='parents').execute()
-            parent_folder_ids = file_metadata.get('parents', [])
+            file_metadata = svc.files().get(fileId=file_id, fields="parents").execute()
+            parent_folder_ids = file_metadata.get("parents", [])
             # Construct URLs to the parent folders based on their IDs
             for folder_id in parent_folder_ids:
-                folder_url = f'https://drive.google.com/drive/folders/{folder_id}'
-                logging.error('Folder URL: %s', folder_url)
+                folder_url = f"https://drive.google.com/drive/folders/{folder_id}"
+                logging.error("Folder URL: %s", folder_url)
         except HttpError as error_msg:
-            logging.error('ERROR-PARENT: %s', error_msg)
+            logging.error("ERROR-PARENT: %s", error_msg)
 
     # Write the error to the log file
-    logging.error('COPY FAILED: %s: %s', file_or_folder_name, error)
+    logging.error("COPY FAILED: %s: %s", file_or_folder_name, error)
+
 
 # Define a function to recursively add child records to the CSV
 def add_child_folders(folder_id, writer, drive_service=None):
@@ -309,18 +338,22 @@ def add_child_folders(folder_id, writer, drive_service=None):
         drive_service: The Google Drive service object (optional, uses global if not provided).
     """
     svc = drive_service or service
-    query = (f"'{folder_id}' in parents and "
-         f"mimeType = '{MIME_FOLDER}' and "
-         f"trashed = false")
-    results = svc.files().list(q=query, orderBy='name asc').execute()
-    folders = results.get('files', [])
+    query = (
+        f"'{folder_id}' in parents and "
+        f"mimeType = '{MIME_FOLDER}' and "
+        f"trashed = false"
+    )
+    results = svc.files().list(q=query, orderBy="name asc").execute()
+    folders = results.get("files", [])
     for folder in folders:
-        folder_id = folder['id']
+        folder_id = folder["id"]
         num_files, num_folders = count_child_objects(folder_id, svc)
-        writer.writerow([folder['name'], num_files, num_folders])
+        writer.writerow([folder["name"], num_files, num_folders])
+
 
 # Enable pylint for no-member again
 # pylint: enable=no-member
+
 
 # Compare the two assessments CSV files
 def compare_csv_files(file1, file2):
@@ -339,34 +372,37 @@ def compare_csv_files(file1, file2):
     if assessment2.equals(assessment3):
         logging.info("VALIDATION SUCCESSFUL!")
     else:
-        logging.error("VALIDATION FAILED - Source & Destination folder counts do not match.")
+        logging.error(
+            "VALIDATION FAILED - Source & Destination folder counts do not match."
+        )
         print("ERROR: VALIDATION FAILED!")
+
 
 def main(argv=None):
     """Main entry point for CLI."""
     global service  # pylint: disable=global-statement
 
     parser = argparse.ArgumentParser(
-        prog='drive-copy',
-        description='Google Drive report and copy utility',
+        prog="drive-copy",
+        description="Google Drive report and copy utility",
     )
     parser.add_argument(
-        '--help-env',
-        action='store_true',
-        help='Show required environment variables and exit',
+        "--help-env",
+        action="store_true",
+        help="Show required environment variables and exit",
     )
     parser.add_argument(
-        '--dry-run',
-        action='store_true',
-        help='Preview source counts and planned copy target without writing outputs or copying files',
+        "--dry-run",
+        action="store_true",
+        help="Preview source counts and planned copy target without writing outputs or copying files",
     )
     args, _ = parser.parse_known_args(argv)
 
     if args.help_env:
-        print('Required environment variables:')
-        print(f'- {CLIENT_ID_ENV_VAR}')
-        print(f'- {SOURCE_FOLDER_ID_ENV_VAR}')
-        print(f'- {DESTINATION_FOLDER_ID_ENV_VAR}')
+        print("Required environment variables:")
+        print(f"- {CLIENT_ID_ENV_VAR}")
+        print(f"- {SOURCE_FOLDER_ID_ENV_VAR}")
+        print(f"- {DESTINATION_FOLDER_ID_ENV_VAR}")
         return
 
     if not args.dry_run:
@@ -374,8 +410,8 @@ def main(argv=None):
         # This is done here (not at module level) to avoid FileNotFoundError on import
         # when the directory does not yet exist (the original RCA for CI failures).
         os.makedirs(OUTPUTS_DIRECTORY, exist_ok=True)
-        timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M')
-        log_file_path = os.path.join(OUTPUTS_DIRECTORY, f'gcp-{timestamp}.log')
+        timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M")
+        log_file_path = os.path.join(OUTPUTS_DIRECTORY, f"gcp-{timestamp}.log")
         file_handler = logging.FileHandler(log_file_path)
         file_handler.setFormatter(logging.Formatter(LOG_FILE_FORMAT))
         logging.getLogger().addHandler(file_handler)
@@ -390,11 +426,17 @@ def main(argv=None):
 
     # Check if the environment variables are set
     if not client_id_file:
-        raise ValueError(f"{MISSING_ENVAR_TXT} Google Drive API Client ID JSON: {CLIENT_ID_ENV_VAR}")
+        raise ValueError(
+            f"{MISSING_ENVAR_TXT} Google Drive API Client ID JSON: {CLIENT_ID_ENV_VAR}"
+        )
     if not source_folder_id:
-        raise ValueError(f"{MISSING_ENVAR_TXT} Source folder ID: {SOURCE_FOLDER_ID_ENV_VAR}")
+        raise ValueError(
+            f"{MISSING_ENVAR_TXT} Source folder ID: {SOURCE_FOLDER_ID_ENV_VAR}"
+        )
     if not destination_folder_id:
-        raise ValueError(f"{MISSING_ENVAR_TXT} Destination folder ID: {DESTINATION_FOLDER_ID_ENV_VAR}")
+        raise ValueError(
+            f"{MISSING_ENVAR_TXT} Destination folder ID: {DESTINATION_FOLDER_ID_ENV_VAR}"
+        )
 
     # Authenticate and authorize the user
     authed_credentials = authenticate_and_authorize(client_id_file, SCOPES)
@@ -408,22 +450,30 @@ def main(argv=None):
 
     # Get folder names
     # pylint: disable=no-member
-    source_folder_name = service.files().get(fileId=source_folder_id, fields='name').execute()
-    destination_folder_name = service.files().get(fileId=destination_folder_id, fields='name').execute()
+    source_folder_name = (
+        service.files().get(fileId=source_folder_id, fields="name").execute()
+    )
+    destination_folder_name = (
+        service.files().get(fileId=destination_folder_id, fields="name").execute()
+    )
     # pylint: enable=no-member
 
     total_num_files, total_num_folders = count_child_objects(source_folder_id, service)
 
     if args.dry_run:
-        print('DRY RUN: no files will be copied and no output artifacts will be written.')
+        print(
+            "DRY RUN: no files will be copied and no output artifacts will be written."
+        )
         print(
             f"Source '{source_folder_name['name']}' -> Destination '{destination_folder_name['name']}'"
         )
-        print(f'Planned object scan: files={total_num_files}, folders={total_num_folders}')
+        print(
+            f"Planned object scan: files={total_num_files}, folders={total_num_folders}"
+        )
         logging.info(
             "DRY RUN: source=%s destination=%s files=%d folders=%d",
-            source_folder_name['name'],
-            destination_folder_name['name'],
+            source_folder_name["name"],
+            destination_folder_name["name"],
             total_num_files,
             total_num_folders,
         )
@@ -431,51 +481,60 @@ def main(argv=None):
 
     logging.info("STARTING ASSESSMENTS...")
     # ASSESSEMENT 1 - Write the results to a CSV file
-    csv_file = './outputs/assessment-1.csv'
-    with open(csv_file, 'w', newline='', encoding='utf-8') as output_file:
+    csv_file = "./outputs/assessment-1.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as output_file:
         # Get the name of the source folder
         writer = csv.writer(output_file)
-        writer.writerow(['Folder Name', 'Number of Files', 'Number of Folders'])
-        writer.writerow([source_folder_name['name'], total_num_files, total_num_folders])
+        writer.writerow(["Folder Name", "Number of Files", "Number of Folders"])
+        writer.writerow(
+            [source_folder_name["name"], total_num_files, total_num_folders]
+        )
 
     # ASSESSEMENT 2 - Write the results to a CSV file
-    csv_file = './outputs/assessment-2.csv'
-    with open(csv_file, 'w', newline='', encoding='utf-8') as output_file:
+    csv_file = "./outputs/assessment-2.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as output_file:
         writer = csv.writer(output_file)
-        writer.writerow(['Folder Name', 'Number of Files', 'Number of Child Folders'])
+        writer.writerow(["Folder Name", "Number of Files", "Number of Child Folders"])
         # Write the Total at the top of the CSV
-        total_num_files, total_num_folders = count_child_objects(source_folder_id, service)
-        writer.writerow(['TOTAL', total_num_files, total_num_folders])
+        total_num_files, total_num_folders = count_child_objects(
+            source_folder_id, service
+        )
+        writer.writerow(["TOTAL", total_num_files, total_num_folders])
         add_child_folders(source_folder_id, writer, service)
 
     # Copy all child objects (including nested folders and files) to the new top-level folder
-    logging.info("STARTING COPY TO %s...", destination_folder_name['name'])
+    logging.info("STARTING COPY TO %s...", destination_folder_name["name"])
     copy_child_objects(source_folder_id, destination_folder_id, service)
     logging.info("COPY COMPLETED!")
 
     # ASSESSEMENT 3 - Write the results to a CSV file
-    csv_file = './outputs/assessment-3.csv'
-    with open(csv_file, 'w', newline='', encoding='utf-8') as output_file:
+    csv_file = "./outputs/assessment-3.csv"
+    with open(csv_file, "w", newline="", encoding="utf-8") as output_file:
         writer = csv.writer(output_file)
-        writer.writerow(['Folder Name', 'Number of Files', 'Number of Child Folders'])
+        writer.writerow(["Folder Name", "Number of Files", "Number of Child Folders"])
 
         # Write the Total at the top of the CSV
-        total_num_files, total_num_folders = count_child_objects(destination_folder_id, service)
-        writer.writerow(['TOTAL', total_num_files, total_num_folders])
+        total_num_files, total_num_folders = count_child_objects(
+            destination_folder_id, service
+        )
+        writer.writerow(["TOTAL", total_num_files, total_num_folders])
         add_child_folders(destination_folder_id, writer, service)
 
     logging.info("ASSESSMENTS COMPLETED!")
 
     logging.info("STARTING VALIDATION...")
     # Load source and destination file count CSV reports
-    output_2 = './outputs/assessment-2.csv'
-    output_3 = './outputs/assessment-3.csv'
+    output_2 = "./outputs/assessment-2.csv"
+    output_3 = "./outputs/assessment-3.csv"
 
     compare_csv_files(output_2, output_3)
 
     # FINISH SCRIPT
-    logging.info("COPIED: %s to %s", source_folder_name['name'], destination_folder_name['name'])
+    logging.info(
+        "COPIED: %s to %s", source_folder_name["name"], destination_folder_name["name"]
+    )
     print("SCRIPT COMPLETED!")
+
 
 if __name__ == "__main__":
     main()

--- a/gcp/copy_folder.py
+++ b/gcp/copy_folder.py
@@ -6,6 +6,7 @@ import os
 import csv
 import logging
 import datetime
+import time
 import pandas as pd
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
@@ -25,6 +26,7 @@ DESTINATION_FOLDER_ID_ENV_VAR = 'GOOGLE_DRIVE_DESTINATION_FOLDER_ID'
 # Script Constants
 MISSING_ENVAR_TXT = 'Missing environment variable for'
 MIME_FOLDER = 'application/vnd.google-apps.folder'
+DEFAULT_PROGRESS_LOG_EVERY = 25
 
 # Directories and filenames
 OUTPUTS_DIRECTORY = './outputs/'
@@ -142,7 +144,51 @@ def count_child_objects(folder_id, drive_service=None):
     return num_files, num_folders
 
 # Define a function to copy child objects recursively
-def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None, max_retries=1):
+def _create_progress_tracker(progress_log_every):
+    return {
+        'start_time': time.monotonic(),
+        'copied_files': 0,
+        'created_folders': 0,
+        'failed_files': 0,
+        'processed_since_log': 0,
+        'progress_log_every': max(1, int(progress_log_every)),
+    }
+
+
+def _log_progress_if_needed(progress_tracker, force=False):
+    if not force and progress_tracker['processed_since_log'] < progress_tracker['progress_log_every']:
+        return
+
+    elapsed = time.monotonic() - progress_tracker['start_time']
+    logging.info(
+        'COPY PROGRESS: files=%d folders=%d failed=%d elapsed=%.2fs',
+        progress_tracker['copied_files'],
+        progress_tracker['created_folders'],
+        progress_tracker['failed_files'],
+        elapsed,
+    )
+    progress_tracker['processed_since_log'] = 0
+
+
+def _log_progress_summary(progress_tracker):
+    elapsed = time.monotonic() - progress_tracker['start_time']
+    logging.info(
+        'COPY PROGRESS SUMMARY: files=%d folders=%d failed=%d total_elapsed=%.2fs',
+        progress_tracker['copied_files'],
+        progress_tracker['created_folders'],
+        progress_tracker['failed_files'],
+        elapsed,
+    )
+
+
+def copy_child_objects(
+    src_folder_id,
+    dest_folder_id,
+    drive_service=None,
+    max_retries=1,
+    progress_tracker=None,
+    progress_log_every=DEFAULT_PROGRESS_LOG_EVERY,
+):
     """
     Copies all child objects (files and folders) from source folder to a destination folder.
     Includes a static retry mechanism for file copy failures.
@@ -154,6 +200,8 @@ def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None, max_re
         max_retries=1 (int): The maximum number of times to retry copying a file before giving up.
     """
     svc = drive_service or service
+    root_call = progress_tracker is None
+    tracker = progress_tracker or _create_progress_tracker(progress_log_every)
     # List files in the source folder
     query = f"'{src_folder_id}' in parents"
     results = svc.files().list(q=query).execute()
@@ -168,6 +216,9 @@ def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None, max_re
                 try:
                     # Attempt to copy the file
                     svc.files().copy(fileId=file['id'], body=file_metadata).execute()
+                    tracker['copied_files'] += 1
+                    tracker['processed_since_log'] += 1
+                    _log_progress_if_needed(tracker)
                     # If the copy is successful, break out of the retry loop
                     break
                 except HttpError as error_msg:
@@ -179,6 +230,9 @@ def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None, max_re
                         # If all retries fail, log the error and move on to the next file
                         logging.error("Error copying file %s after %d retries: %s",
                                       file['name'], max_retries, error_msg)
+                        tracker['failed_files'] += 1
+                        tracker['processed_since_log'] += 1
+                        _log_progress_if_needed(tracker)
                         break
 
     except HttpError as error_msg:
@@ -199,8 +253,22 @@ def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None, max_re
             'mimeType': 'application/vnd.google-apps.folder'
         }
         new_folder = svc.files().create(body=new_folder_metadata, fields='id').execute()
+        tracker['created_folders'] += 1
+        tracker['processed_since_log'] += 1
+        _log_progress_if_needed(tracker)
         # Recursively copy the child objects into the new folder
-        copy_child_objects(folder['id'], new_folder['id'], svc)
+        copy_child_objects(
+            folder['id'],
+            new_folder['id'],
+            svc,
+            max_retries=max_retries,
+            progress_tracker=tracker,
+            progress_log_every=progress_log_every,
+        )
+
+    if root_call:
+        _log_progress_if_needed(tracker, force=True)
+        _log_progress_summary(tracker)
 
 # Define a function to handle copy errors
 def handle_copy_error(file_or_folder_name, error, drive_service=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,5 +44,8 @@ addopts = "-v --tb=short"
 [tool.pylint.messages_control]
 disable = ["C0111", "C0103"]
 
+[tool.isort]
+profile = "black"
+
 [tool.bandit]
 exclude_dirs = ["tests", "testing"]

--- a/tests/test_copy_folder_extended.py
+++ b/tests/test_copy_folder_extended.py
@@ -1,6 +1,6 @@
 """Extended tests for Google Drive copy_folder functionality - Phase 2."""
 # pylint: disable=redefined-outer-name,import-outside-toplevel
-from unittest.mock import Mock, MagicMock
+from unittest.mock import Mock, MagicMock, patch
 import csv
 import tempfile
 import pytest
@@ -178,6 +178,34 @@ class TestCopyChildObjects:
         copy_child_objects('src', 'dest', mock_service, max_retries=2)
 
         assert mock_service.files().copy.call_count >= 2
+
+    def test_copy_child_objects_logs_progress_and_summary(self, mock_service):
+        """Test progress telemetry and final duration summary logging."""
+        mock_service.files().list().execute.side_effect = [
+            {
+                'files': [
+                    {'id': 'file1', 'name': 'doc1.txt'},
+                    {'id': 'file2', 'name': 'doc2.txt'},
+                ]
+            },
+            {'files': []},
+        ]
+        mock_service.files().copy().execute.return_value = {'id': 'new_file'}
+
+        with patch('gcp.copy_folder.logging.info') as mock_info:
+            copy_child_objects('src', 'dest', mock_service, progress_log_every=1)
+
+        progress_calls = [
+            call for call in mock_info.call_args_list
+            if call.args and isinstance(call.args[0], str) and call.args[0].startswith('COPY PROGRESS:')
+        ]
+        summary_calls = [
+            call for call in mock_info.call_args_list
+            if call.args and isinstance(call.args[0], str) and call.args[0].startswith('COPY PROGRESS SUMMARY:')
+        ]
+
+        assert len(progress_calls) >= 1
+        assert len(summary_calls) == 1
 
 
 class TestHandleCopyError:

--- a/tests/test_copy_folder_extended.py
+++ b/tests/test_copy_folder_extended.py
@@ -1,16 +1,19 @@
 """Extended tests for Google Drive copy_folder functionality - Phase 2."""
+
 # pylint: disable=redefined-outer-name,import-outside-toplevel
-from unittest.mock import Mock, MagicMock, patch
 import csv
 import tempfile
+from unittest.mock import MagicMock, Mock, patch
+
 import pytest
 from googleapiclient.errors import HttpError
+
 from gcp.copy_folder import (
-    count_child_objects,
-    copy_child_objects,
-    handle_copy_error,
     add_child_folders,
     compare_csv_files,
+    copy_child_objects,
+    count_child_objects,
+    handle_copy_error,
 )
 
 
@@ -26,9 +29,9 @@ class TestCountChildObjects:
 
     def test_count_child_objects_empty_folder(self, mock_service):
         """Test counting in an empty folder."""
-        mock_service.files().list().execute.return_value = {'files': []}
+        mock_service.files().list().execute.return_value = {"files": []}
 
-        num_files, num_folders = count_child_objects('empty_folder_id', mock_service)
+        num_files, num_folders = count_child_objects("empty_folder_id", mock_service)
 
         assert num_files == 0
         assert num_folders == 0
@@ -36,14 +39,14 @@ class TestCountChildObjects:
     def test_count_child_objects_files_only(self, mock_service):
         """Test counting files without subfolders."""
         mock_service.files().list().execute.return_value = {
-            'files': [
-                {'id': '1', 'name': 'file1.txt', 'mimeType': 'text/plain'},
-                {'id': '2', 'name': 'file2.pdf', 'mimeType': 'application/pdf'},
-                {'id': '3', 'name': 'file3.jpg', 'mimeType': 'image/jpeg'},
+            "files": [
+                {"id": "1", "name": "file1.txt", "mimeType": "text/plain"},
+                {"id": "2", "name": "file2.pdf", "mimeType": "application/pdf"},
+                {"id": "3", "name": "file3.jpg", "mimeType": "image/jpeg"},
             ]
         }
 
-        num_files, num_folders = count_child_objects('folder_id', mock_service)
+        num_files, num_folders = count_child_objects("folder_id", mock_service)
 
         assert num_files == 3
         assert num_folders == 0
@@ -53,16 +56,24 @@ class TestCountChildObjects:
         # First call returns folders, subsequent calls return empty (folders are empty)
         mock_service.files().list().execute.side_effect = [
             {
-                'files': [
-                    {'id': 'f1', 'name': 'folder1', 'mimeType': 'application/vnd.google-apps.folder'},
-                    {'id': 'f2', 'name': 'folder2', 'mimeType': 'application/vnd.google-apps.folder'},
+                "files": [
+                    {
+                        "id": "f1",
+                        "name": "folder1",
+                        "mimeType": "application/vnd.google-apps.folder",
+                    },
+                    {
+                        "id": "f2",
+                        "name": "folder2",
+                        "mimeType": "application/vnd.google-apps.folder",
+                    },
                 ]
             },
-            {'files': []},  # folder1 is empty
-            {'files': []},  # folder2 is empty
+            {"files": []},  # folder1 is empty
+            {"files": []},  # folder2 is empty
         ]
 
-        num_files, num_folders = count_child_objects('folder_id', mock_service)
+        num_files, num_folders = count_child_objects("folder_id", mock_service)
 
         assert num_files == 0
         assert num_folders == 2
@@ -73,20 +84,24 @@ class TestCountChildObjects:
         # Subfolder has 2 files
         mock_service.files().list().execute.side_effect = [
             {
-                'files': [
-                    {'id': 'file1', 'name': 'root_file.txt', 'mimeType': 'text/plain'},
-                    {'id': 'subfolder', 'name': 'subfolder', 'mimeType': 'application/vnd.google-apps.folder'},
+                "files": [
+                    {"id": "file1", "name": "root_file.txt", "mimeType": "text/plain"},
+                    {
+                        "id": "subfolder",
+                        "name": "subfolder",
+                        "mimeType": "application/vnd.google-apps.folder",
+                    },
                 ]
             },
             {
-                'files': [
-                    {'id': 'file2', 'name': 'sub_file1.txt', 'mimeType': 'text/plain'},
-                    {'id': 'file3', 'name': 'sub_file2.txt', 'mimeType': 'text/plain'},
+                "files": [
+                    {"id": "file2", "name": "sub_file1.txt", "mimeType": "text/plain"},
+                    {"id": "file3", "name": "sub_file2.txt", "mimeType": "text/plain"},
                 ]
             },
         ]
 
-        num_files, num_folders = count_child_objects('root_folder', mock_service)
+        num_files, num_folders = count_child_objects("root_folder", mock_service)
 
         assert num_files == 3  # 1 root + 2 in subfolder
         assert num_folders == 1
@@ -98,12 +113,12 @@ class TestCopyChildObjects:
     def test_copy_child_objects_empty_folder(self, mock_service):
         """Test copying from an empty folder."""
         mock_service.files().list().execute.side_effect = [
-            {'files': []},  # No files
-            {'files': []},  # No folders
+            {"files": []},  # No files
+            {"files": []},  # No folders
         ]
 
         # Should complete without errors
-        copy_child_objects('src', 'dest', mock_service)
+        copy_child_objects("src", "dest", mock_service)
 
         # Verify no copy operations were attempted
         mock_service.files().copy.assert_not_called()
@@ -112,16 +127,16 @@ class TestCopyChildObjects:
         """Test copying files without folders."""
         mock_service.files().list().execute.side_effect = [
             {
-                'files': [
-                    {'id': 'file1', 'name': 'doc.txt'},
-                    {'id': 'file2', 'name': 'image.jpg'},
+                "files": [
+                    {"id": "file1", "name": "doc.txt"},
+                    {"id": "file2", "name": "image.jpg"},
                 ]
             },
-            {'files': []},  # No folders
+            {"files": []},  # No folders
         ]
-        mock_service.files().copy().execute.return_value = {'id': 'new_file'}
+        mock_service.files().copy().execute.return_value = {"id": "new_file"}
 
-        copy_child_objects('src', 'dest', mock_service)
+        copy_child_objects("src", "dest", mock_service)
 
         # Verify files were copied (MagicMock counts call() as one call)
         assert mock_service.files().copy.call_count >= 2
@@ -129,15 +144,15 @@ class TestCopyChildObjects:
     def test_copy_child_objects_with_folders(self, mock_service):
         """Test copying files and folders."""
         mock_service.files().list().execute.side_effect = [
-            {'files': [{'id': 'file1', 'name': 'doc.txt'}]},  # Files in root
-            {'files': [{'id': 'folder1', 'name': 'subfolder'}]},  # Folders in root
-            {'files': []},  # Files in subfolder
-            {'files': []},  # Folders in subfolder
+            {"files": [{"id": "file1", "name": "doc.txt"}]},  # Files in root
+            {"files": [{"id": "folder1", "name": "subfolder"}]},  # Folders in root
+            {"files": []},  # Files in subfolder
+            {"files": []},  # Folders in subfolder
         ]
-        mock_service.files().copy().execute.return_value = {'id': 'new_file'}
-        mock_service.files().create().execute.return_value = {'id': 'new_folder'}
+        mock_service.files().copy().execute.return_value = {"id": "new_file"}
+        mock_service.files().create().execute.return_value = {"id": "new_folder"}
 
-        copy_child_objects('src', 'dest', mock_service)
+        copy_child_objects("src", "dest", mock_service)
 
         # Verify file copy was called
         assert mock_service.files().copy.call_count >= 1
@@ -147,18 +162,18 @@ class TestCopyChildObjects:
     def test_copy_child_objects_with_retry(self, mock_service):
         """Test retry mechanism on file copy failure."""
         mock_service.files().list().execute.side_effect = [
-            {'files': [{'id': 'file1', 'name': 'doc.txt'}]},
-            {'files': []},
+            {"files": [{"id": "file1", "name": "doc.txt"}]},
+            {"files": []},
         ]
 
         # Simulate failure then success
-        http_error = HttpError(resp=Mock(status=500), content=b'Server Error')
+        http_error = HttpError(resp=Mock(status=500), content=b"Server Error")
         mock_service.files().copy().execute.side_effect = [
             http_error,
-            {'id': 'new_file'},
+            {"id": "new_file"},
         ]
 
-        copy_child_objects('src', 'dest', mock_service, max_retries=2)
+        copy_child_objects("src", "dest", mock_service, max_retries=2)
 
         # Verify retry was attempted (includes the initial call() which is counted)
         assert mock_service.files().copy.call_count >= 2
@@ -166,16 +181,16 @@ class TestCopyChildObjects:
     def test_copy_child_objects_max_retries_exceeded(self, mock_service):
         """Test that retries eventually give up."""
         mock_service.files().list().execute.side_effect = [
-            {'files': [{'id': 'file1', 'name': 'doc.txt'}]},
-            {'files': []},
+            {"files": [{"id": "file1", "name": "doc.txt"}]},
+            {"files": []},
         ]
 
         # Simulate continuous failure
-        http_error = HttpError(resp=Mock(status=500), content=b'Server Error')
+        http_error = HttpError(resp=Mock(status=500), content=b"Server Error")
         mock_service.files().copy().execute.side_effect = http_error
 
         # Should not raise, just log and continue
-        copy_child_objects('src', 'dest', mock_service, max_retries=2)
+        copy_child_objects("src", "dest", mock_service, max_retries=2)
 
         assert mock_service.files().copy.call_count >= 2
 
@@ -183,25 +198,31 @@ class TestCopyChildObjects:
         """Test progress telemetry and final duration summary logging."""
         mock_service.files().list().execute.side_effect = [
             {
-                'files': [
-                    {'id': 'file1', 'name': 'doc1.txt'},
-                    {'id': 'file2', 'name': 'doc2.txt'},
+                "files": [
+                    {"id": "file1", "name": "doc1.txt"},
+                    {"id": "file2", "name": "doc2.txt"},
                 ]
             },
-            {'files': []},
+            {"files": []},
         ]
-        mock_service.files().copy().execute.return_value = {'id': 'new_file'}
+        mock_service.files().copy().execute.return_value = {"id": "new_file"}
 
-        with patch('gcp.copy_folder.logging.info') as mock_info:
-            copy_child_objects('src', 'dest', mock_service, progress_log_every=1)
+        with patch("gcp.copy_folder.logging.info") as mock_info:
+            copy_child_objects("src", "dest", mock_service, progress_log_every=1)
 
         progress_calls = [
-            call for call in mock_info.call_args_list
-            if call.args and isinstance(call.args[0], str) and call.args[0].startswith('COPY PROGRESS:')
+            call
+            for call in mock_info.call_args_list
+            if call.args
+            and isinstance(call.args[0], str)
+            and call.args[0].startswith("COPY PROGRESS:")
         ]
         summary_calls = [
-            call for call in mock_info.call_args_list
-            if call.args and isinstance(call.args[0], str) and call.args[0].startswith('COPY PROGRESS SUMMARY:')
+            call
+            for call in mock_info.call_args_list
+            if call.args
+            and isinstance(call.args[0], str)
+            and call.args[0].startswith("COPY PROGRESS SUMMARY:")
         ]
 
         assert len(progress_calls) >= 1
@@ -216,33 +237,33 @@ class TestHandleCopyError:
         error = Exception("Test error")
 
         # Should not raise, just log
-        handle_copy_error('test_file.txt', error, mock_service)
+        handle_copy_error("test_file.txt", error, mock_service)
 
     def test_handle_copy_error_with_http_error(self, mock_service):
         """Test handling HttpError with file metadata retrieval."""
-        http_error = HttpError(resp=Mock(status=404), content=b'Not Found')
-        http_error.__dict__['fileId'] = 'file123'
+        http_error = HttpError(resp=Mock(status=404), content=b"Not Found")
+        http_error.__dict__["fileId"] = "file123"
 
         mock_service.files().get().execute.return_value = {
-            'parents': ['parent_folder_id']
+            "parents": ["parent_folder_id"]
         }
 
-        handle_copy_error('test_file.txt', http_error, mock_service)
+        handle_copy_error("test_file.txt", http_error, mock_service)
 
         # Verify parent folder lookup was attempted (call count includes call())
         assert mock_service.files().get.call_count >= 1
 
     def test_handle_copy_error_parent_lookup_fails(self, mock_service):
         """Test when parent folder lookup fails."""
-        http_error = HttpError(resp=Mock(status=404), content=b'Not Found')
-        http_error.__dict__['fileId'] = 'file123'
+        http_error = HttpError(resp=Mock(status=404), content=b"Not Found")
+        http_error.__dict__["fileId"] = "file123"
 
         # Simulate parent lookup failure
-        parent_error = HttpError(resp=Mock(status=403), content=b'Forbidden')
+        parent_error = HttpError(resp=Mock(status=403), content=b"Forbidden")
         mock_service.files().get().execute.side_effect = parent_error
 
         # Should not raise, just log both errors
-        handle_copy_error('test_file.txt', http_error, mock_service)
+        handle_copy_error("test_file.txt", http_error, mock_service)
 
 
 class TestAddChildFolders:
@@ -250,11 +271,13 @@ class TestAddChildFolders:
 
     def test_add_child_folders_empty(self, mock_service):
         """Test adding child folders when there are none."""
-        mock_service.files().list().execute.return_value = {'files': []}
+        mock_service.files().list().execute.return_value = {"files": []}
 
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, newline='', encoding='utf-8') as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, newline="", encoding="utf-8"
+        ) as f:
             writer = csv.writer(f)
-            add_child_folders('folder_id', writer, mock_service)
+            add_child_folders("folder_id", writer, mock_service)
 
         # No folders to add, writer should not be called
 
@@ -265,32 +288,34 @@ class TestAddChildFolders:
         # count_child_objects queries for all items (files and folders)
         mock_service.files().list().execute.side_effect = [
             {
-                'files': [
-                    {'id': 'folder1', 'name': 'Documents'},
-                    {'id': 'folder2', 'name': 'Pictures'},
+                "files": [
+                    {"id": "folder1", "name": "Documents"},
+                    {"id": "folder2", "name": "Pictures"},
                 ]
             },
             # For Documents folder - count_child_objects queries once for all items
-            {'files': [{'id': 'file1', 'name': 'doc.txt', 'mimeType': 'text/plain'}]},
+            {"files": [{"id": "file1", "name": "doc.txt", "mimeType": "text/plain"}]},
             # For Pictures folder - count_child_objects queries once for all items
-            {'files': [{'id': 'file2', 'name': 'pic.jpg', 'mimeType': 'image/jpeg'}]},
+            {"files": [{"id": "file2", "name": "pic.jpg", "mimeType": "image/jpeg"}]},
         ]
 
-        with tempfile.NamedTemporaryFile(mode='w', delete=False, newline='', encoding='utf-8') as f:
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, newline="", encoding="utf-8"
+        ) as f:
             writer = csv.writer(f)
-            writer.writerow(['Folder Name', 'Number of Files', 'Number of Folders'])
-            add_child_folders('parent_id', writer, mock_service)
+            writer.writerow(["Folder Name", "Number of Files", "Number of Folders"])
+            add_child_folders("parent_id", writer, mock_service)
             f.flush()
 
             # Read back and verify
-            with open(f.name, 'r', encoding='utf-8') as rf:
+            with open(f.name, "r", encoding="utf-8") as rf:
                 reader = csv.reader(rf)
                 next(reader)  # Skip header
                 rows = list(reader)
                 assert len(rows) == 2
                 # CSV reader returns strings
-                assert rows[0] == ['Documents', '1', '0']
-                assert rows[1] == ['Pictures', '1', '0']
+                assert rows[0] == ["Documents", "1", "0"]
+                assert rows[1] == ["Pictures", "1", "0"]
 
 
 class TestCompareCSVFiles:
@@ -301,10 +326,10 @@ class TestCompareCSVFiles:
         file1 = tmp_path / "test1.csv"
         file2 = tmp_path / "test2.csv"
 
-        data = [['Name', 'Files', 'Folders'], ['Folder1', 10, 5]]
+        data = [["Name", "Files", "Folders"], ["Folder1", 10, 5]]
 
         for f in [file1, file2]:
-            with open(f, 'w', newline='', encoding='utf-8') as csvfile:
+            with open(f, "w", newline="", encoding="utf-8") as csvfile:
                 writer = csv.writer(csvfile)
                 writer.writerows(data)
 
@@ -316,13 +341,13 @@ class TestCompareCSVFiles:
         file1 = tmp_path / "test1.csv"
         file2 = tmp_path / "test2.csv"
 
-        with open(file1, 'w', newline='', encoding='utf-8') as f:
+        with open(file1, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerows([['Name', 'Files', 'Folders'], ['Folder1', 10, 5]])
+            writer.writerows([["Name", "Files", "Folders"], ["Folder1", 10, 5]])
 
-        with open(file2, 'w', newline='', encoding='utf-8') as f:
+        with open(file2, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerows([['Name', 'Files', 'Folders'], ['Folder1', 15, 5]])
+            writer.writerows([["Name", "Files", "Folders"], ["Folder1", 15, 5]])
 
         # Should log failure but not raise
         compare_csv_files(str(file1), str(file2))
@@ -332,13 +357,13 @@ class TestCompareCSVFiles:
         file1 = tmp_path / "test1.csv"
         file2 = tmp_path / "test2.csv"
 
-        with open(file1, 'w', newline='', encoding='utf-8') as f:
+        with open(file1, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerows([['Name', 'Files'], ['Folder1', 10]])
+            writer.writerows([["Name", "Files"], ["Folder1", 10]])
 
-        with open(file2, 'w', newline='', encoding='utf-8') as f:
+        with open(file2, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerows([['Name', 'Files', 'Folders'], ['Folder1', 10, 5]])
+            writer.writerows([["Name", "Files", "Folders"], ["Folder1", 10, 5]])
 
         # Should log failure
         compare_csv_files(str(file1), str(file2))


### PR DESCRIPTION
Addresses linting failures in `gcp/copy_folder.py` and `tests/test_copy_folder_extended.py` introduced by the progress telemetry commit.

## Summary

Three linting issues were present: black formatting drift, isort/black incompatibility, and a pylint `R0917 too-many-positional-arguments` violation on `copy_child_objects`.

## Changes

- **Black**: reformatted both files to comply with black style
- **isort**: added `[tool.isort] profile = "black"` to `pyproject.toml` — without this, isort and black conflict on import line wrapping
- **Pylint R0917**: added `*` keyword-only separator after `drive_service` in `copy_child_objects`, reducing positional parameter count from 6 → 3; all existing callers already used the trailing params as keyword arguments — no breaking change

```python
# Before (6 positional params → R0917)
def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None,
                       max_retries=1, progress_tracker=None, progress_log_every=...):

# After (3 positional + keyword-only)
def copy_child_objects(src_folder_id, dest_folder_id, drive_service=None,
                       *, max_retries=1, progress_tracker=None, progress_log_every=...):
```

## Testing

```
pytest tests/test_copy_folder_extended.py -q  # 18 passed
pylint gcp/copy_folder.py tests/test_copy_folder_extended.py  # 10.00/10
black --check --target-version py312 gcp/ tests/
isort --check-only gcp/ tests/
```

## Screenshots (optional)

N/A

## Checklist

- [x] Tests added or updated
- [x] Documentation updated (if needed)
- [x] Linked to related issues / tasks
- [x] Follows project conventions
- [x] Code is well-documented and readable
- [x] Commits are logically organized