### PR TITLE
roadmap: duplicate detection + permission mirroring for GCP Drive tools

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,3 +9,5 @@ Last Updated: 2026-06-08
 ## 2026 Q4 (Exploratory)
 
 - [ ] Evaluate a lightweight web UI for credential and folder configuration
+- [ ] **Duplicate detection report** — before or after a copy run, generate a CSV of files with identical names and sizes across source and destination; helps identify redundant copies and cleanup candidates alongside the existing assessment reports.
+- [ ] **Permission mirroring** (`--mirror-permissions`) — copy ACL/sharing settings from source files and folders to their destination counterparts so migrated content retains its original access controls instead of defaulting to destination-owner-only access.


### PR DESCRIPTION
## Summary
- Adds **Duplicate detection report** to Q4 Exploratory — CSV of files with identical names and sizes across source/destination, helping identify redundant copies
- Adds **Permission mirroring** (`--mirror-permissions`) to Q4 Exploratory — copies ACL/sharing settings from source to destination so migrated files retain their original access controls

## Test plan
- [ ] ROADMAP.md renders correctly
- [ ] 80 existing tests pass (all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)